### PR TITLE
feature/ファイル名修正関数内のlsコマンドにソートオプションを追加

### DIFF
--- a/src/trim_and_rename.js
+++ b/src/trim_and_rename.js
@@ -10,7 +10,7 @@ const assetsDir = process.env.ASSET_DIR
 const outputsDir = process.env.EPUB_IMAGE_DIR
 const imageExtension = process.env.IMAGE_EXTENSION
 
-const stdout = execSync(`ls ${assetsDir}`)
+const stdout = execSync(`ls ${assetsDir} -tr`)
 const fileList = stdout.toString().split('\n')
 
 const startNumber = 1


### PR DESCRIPTION
# Overview

ファイル名修正関数内のlsコマンドにソートオプションを追加

# Why

ファイル名の日付フォーマットによって、日付順に並ばないことがあるため

# How

- lsコマンドに -tr オプションを付与
